### PR TITLE
[Draft] Fix Portkey SDK Timeout Bug

### DIFF
--- a/.meeting-notes/10e37e45-1b38-420a-8b79-ac783a671655.md
+++ b/.meeting-notes/10e37e45-1b38-420a-8b79-ac783a671655.md
@@ -1,0 +1,8 @@
+# Fix Portkey SDK Timeout Bug
+
+Ensure the Portkey SDK respects the timeout parameter to prevent indefinite hangs.
+
+## Acceptance Criteria
+Portkey SDK respects the 5-second timeout parameter.,Timeout mechanism works consistently across all requests.
+
+<!-- altor:run=a5152789-5b73-420d-b025-37cf2ae89c53:item=10e37e45-1b38-420a-8b79-ac783a671655 -->


### PR DESCRIPTION
⚠️ **This is a placeholder PR from a meeting transcript.**

Ensure the Portkey SDK respects the timeout parameter to prevent indefinite hangs.

## Acceptance Criteria
Portkey SDK respects the 5-second timeout parameter.,Timeout mechanism works consistently across all requests.

---
🎫 Related: #6

<!-- altor:run=a5152789-5b73-420d-b025-37cf2ae89c53:item=10e37e45-1b38-420a-8b79-ac783a671655 -->