### PR TITLE
[Draft] Fix Portkey SDK Timeout Bug

### DIFF
--- a/.meeting-notes/af0ffca6-5640-48da-b966-fe6e12be72f3.md
+++ b/.meeting-notes/af0ffca6-5640-48da-b966-fe6e12be72f3.md
@@ -1,0 +1,8 @@
+# Fix Portkey SDK Timeout Bug
+
+Ensure that the Portkey SDK respects the timeout parameter to prevent indefinite hangs.
+
+## Acceptance Criteria
+Portkey SDK respects the configured timeout parameter.,Requests fail at the 5-second timeout if not completed.,Client-side retries are enabled after timeout.
+
+<!-- altor:run=639c84ae-7fd7-4f29-83ac-8546dbceab8e:item=af0ffca6-5640-48da-b966-fe6e12be72f3 -->


### PR DESCRIPTION
⚠️ **This is a placeholder PR from a meeting transcript.**

Ensure that the Portkey SDK respects the timeout parameter to prevent indefinite hangs.

## Acceptance Criteria
Portkey SDK respects the configured timeout parameter.,Requests fail at the 5-second timeout if not completed.,Client-side retries are enabled after timeout.

---
📋 Linear: https://linear.app/portkey/issue/PYL-7/fix-portkey-sdk-timeout-bug
🎫 Related: #26

<!-- altor:run=639c84ae-7fd7-4f29-83ac-8546dbceab8e:item=af0ffca6-5640-48da-b966-fe6e12be72f3 -->