### PR TITLE
Fix Portkey SDK Timeout Bug

### DIFF
--- a/src/portkey-sdk.ts
+++ b/src/portkey-sdk.ts
@@ -1,0 +1,29 @@
+import axios, { AxiosRequestConfig } from 'axios';
+
+class PortkeySDK {
+  private baseUrl: string;
+
+  constructor(baseUrl: string) {
+    this.baseUrl = baseUrl;
+  }
+
+  async request(endpoint: string, timeout: number = 5000): Promise<any> {
+    const config: AxiosRequestConfig = {
+      url: `${this.baseUrl}/${endpoint}`,
+      method: 'GET',
+      timeout: timeout
+    };
+
+    try {
+      const response = await axios(config);
+      return response.data;
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.code === 'ECONNABORTED') {
+        throw new Error('Request timed out');
+      }
+      throw error;
+    }
+  }
+}
+
+export default PortkeySDK;

--- a/tests/portkey-sdk.test.ts
+++ b/tests/portkey-sdk.test.ts
@@ -1,0 +1,35 @@
+import PortkeySDK from '../src/portkey-sdk';
+import nock from 'nock';
+
+const BASE_URL = 'http://localhost';
+
+describe('PortkeySDK', () => {
+  let sdk: PortkeySDK;
+
+  beforeEach(() => {
+    sdk = new PortkeySDK(BASE_URL);
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it('should respect the timeout parameter', async () => {
+    nock(BASE_URL)
+      .get('/test')
+      .delay(6000)
+      .reply(200, { success: true });
+
+    await expect(sdk.request('test', 5000)).rejects.toThrow('Request timed out');
+  });
+
+  it('should not timeout if response is within the limit', async () => {
+    nock(BASE_URL)
+      .get('/test')
+      .delay(3000)
+      .reply(200, { success: true });
+
+    const response = await sdk.request('test', 5000);
+    expect(response).toEqual({ success: true });
+  });
+});


### PR DESCRIPTION
This PR addresses the issue where the Portkey SDK does not respect the timeout parameter, leading to potential indefinite hangs. The changes ensure that timeouts are correctly triggered at 5 seconds, preventing such hangs.

---
📋 Linear: https://linear.app/portkey/issue/PYL-16/fix-portkey-sdk-timeout-bug
🎫 Related: #36

🤖 Generated by GPT-4o