### PR TITLE
Vertex AI schema validation

### DIFF
--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -53,6 +53,7 @@ import {
   getMimeType,
   googleTools,
   recursivelyDeleteUnsupportedParameters,
+  transformGeminiToolParameters,
   transformGoogleTools,
   transformInputAudioPart,
   transformVertexLogprobs,
@@ -290,6 +291,11 @@ export const VertexGoogleChatCompleteConfig: ProviderConfig = {
           if (googleTools.includes(tool.function.name)) {
             tools.push(...transformGoogleTools(tool));
           } else {
+            if (tool.function?.parameters) {
+              tool.function.parameters = transformGeminiToolParameters(
+                tool.function.parameters
+              );
+            }
             functionDeclarations.push(tool.function);
           }
         }

--- a/src/providers/google-vertex-ai/utils.test.ts
+++ b/src/providers/google-vertex-ai/utils.test.ts
@@ -583,12 +583,32 @@ describe('transformGeminiToolParameters', () => {
 
   it('keeps multi-type unions without null as anyOf (identity = Passport | NationalID)', () => {
     const identity = transformed.properties.identity;
-    const union = (identity.anyOf || identity.oneOf) as any[];
-    expect(Array.isArray(union)).toBe(true);
-    expect(union.length).toBe(2);
+    // Should always be anyOf (oneOf is converted to anyOf for Vertex AI compatibility)
+    expect(identity.anyOf).toBeDefined();
+    expect(identity.oneOf).toBeUndefined();
+    expect(Array.isArray(identity.anyOf)).toBe(true);
+    expect(identity.anyOf.length).toBe(2);
     expect(identity.nullable).toBeUndefined();
-    expect(union[0].type).toBe('object');
-    expect(union[1].type).toBe('object');
+    expect(identity.anyOf[0].type).toBe('object');
+    expect(identity.anyOf[1].type).toBe('object');
+  });
+
+  it('converts oneOf to anyOf for Vertex AI compatibility', () => {
+    const schemaWithOneOf = {
+      type: 'object',
+      properties: {
+        value: {
+          oneOf: [{ type: 'string' }, { type: 'number' }],
+        },
+      },
+    };
+    const result = transformGeminiToolParameters(schemaWithOneOf);
+    expect(result.properties.value.anyOf).toBeDefined();
+    expect(result.properties.value.oneOf).toBeUndefined();
+    expect(result.properties.value.anyOf).toEqual([
+      { type: 'string' },
+      { type: 'number' },
+    ]);
   });
 
   it('retains default values/titles when flattening (notes, contact.phone)', () => {
@@ -676,19 +696,36 @@ describe('recursivelyDeleteUnsupportedParameters', () => {
     expect(schema.properties.foo.$ref).toBeUndefined();
   });
 
-  it('removes allOf, oneOf, and not keywords', () => {
+  it('removes allOf and not keywords', () => {
     const schema = {
       type: 'object',
       properties: {
         value: {
           allOf: [{ type: 'string' }, { minLength: 1 }],
-          oneOf: [{ const: 'a' }, { const: 'b' }],
           not: { type: 'null' },
         },
       },
     };
     recursivelyDeleteUnsupportedParameters(schema);
     expect(schema.properties.value).toEqual({});
+  });
+
+  it('preserves oneOf for processing by transformGeminiToolParameters', () => {
+    // oneOf is NOT deleted because transformGeminiToolParameters converts it to anyOf
+    const schema = {
+      type: 'object',
+      properties: {
+        value: {
+          oneOf: [{ type: 'string' }, { type: 'number' }],
+        },
+      },
+    };
+    recursivelyDeleteUnsupportedParameters(schema);
+    expect(schema.properties.value.oneOf).toBeDefined();
+    expect(schema.properties.value.oneOf).toEqual([
+      { type: 'string' },
+      { type: 'number' },
+    ]);
   });
 
   it('removes conditional keywords if/then/else', () => {

--- a/src/providers/google-vertex-ai/utils.test.ts
+++ b/src/providers/google-vertex-ai/utils.test.ts
@@ -1,4 +1,8 @@
-import { derefer, transformGeminiToolParameters } from './utils';
+import {
+  derefer,
+  transformGeminiToolParameters,
+  recursivelyDeleteUnsupportedParameters,
+} from './utils';
 
 /*
 from enum import StrEnum
@@ -614,5 +618,357 @@ describe('transformGeminiToolParameters', () => {
       'identity',
       'emergency_contacts',
     ]);
+  });
+});
+
+describe('recursivelyDeleteUnsupportedParameters', () => {
+  it('removes exclusiveMinimum and exclusiveMaximum from schema', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        age: {
+          type: 'integer',
+          minimum: 0,
+          maximum: 150,
+          exclusiveMinimum: 0,
+          exclusiveMaximum: 200,
+        },
+      },
+    };
+    recursivelyDeleteUnsupportedParameters(schema);
+    expect(schema.properties.age).toEqual({
+      type: 'integer',
+      minimum: 0,
+      maximum: 150,
+    });
+  });
+
+  it('removes additionalProperties and $schema', () => {
+    const schema = {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+      },
+      additionalProperties: false,
+    };
+    recursivelyDeleteUnsupportedParameters(schema);
+    expect(schema).toEqual({
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+      },
+    });
+  });
+
+  it('removes $defs, definitions, and $ref', () => {
+    const schema = {
+      $defs: { Foo: { type: 'string' } },
+      definitions: { Bar: { type: 'number' } },
+      type: 'object',
+      properties: {
+        foo: { $ref: '#/$defs/Foo' },
+      },
+    };
+    recursivelyDeleteUnsupportedParameters(schema);
+    expect(schema.$defs).toBeUndefined();
+    expect((schema as any).definitions).toBeUndefined();
+    expect(schema.properties.foo.$ref).toBeUndefined();
+  });
+
+  it('removes allOf, oneOf, and not keywords', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        value: {
+          allOf: [{ type: 'string' }, { minLength: 1 }],
+          oneOf: [{ const: 'a' }, { const: 'b' }],
+          not: { type: 'null' },
+        },
+      },
+    };
+    recursivelyDeleteUnsupportedParameters(schema);
+    expect(schema.properties.value).toEqual({});
+  });
+
+  it('removes conditional keywords if/then/else', () => {
+    const schema = {
+      type: 'object',
+      if: { properties: { type: { const: 'a' } } },
+      then: { required: ['a_value'] },
+      else: { required: ['b_value'] },
+      properties: {
+        type: { type: 'string' },
+      },
+    };
+    recursivelyDeleteUnsupportedParameters(schema);
+    expect((schema as any).if).toBeUndefined();
+    expect((schema as any).then).toBeUndefined();
+    expect((schema as any).else).toBeUndefined();
+  });
+
+  it('removes const keyword', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        status: {
+          type: 'string',
+          const: 'active',
+        },
+      },
+    };
+    recursivelyDeleteUnsupportedParameters(schema);
+    expect(schema.properties.status).toEqual({ type: 'string' });
+  });
+
+  it('removes annotation keywords (examples, deprecated, readOnly, writeOnly)', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          examples: ['John', 'Jane'],
+          deprecated: true,
+          readOnly: true,
+          writeOnly: false,
+        },
+      },
+    };
+    recursivelyDeleteUnsupportedParameters(schema);
+    expect(schema.properties.name).toEqual({ type: 'string' });
+  });
+
+  it('removes content keywords (contentEncoding, contentMediaType, contentSchema)', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        document: {
+          type: 'string',
+          contentEncoding: 'base64',
+          contentMediaType: 'application/pdf',
+          contentSchema: { type: 'object' },
+        },
+      },
+    };
+    recursivelyDeleteUnsupportedParameters(schema);
+    expect(schema.properties.document).toEqual({ type: 'string' });
+  });
+
+  it('removes array-specific unsupported keywords (contains, prefixItems, uniqueItems)', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        items: {
+          type: 'array',
+          items: { type: 'string' },
+          contains: { type: 'string', const: 'required' },
+          prefixItems: [{ type: 'string' }],
+          uniqueItems: true,
+          minContains: 1,
+          maxContains: 5,
+        },
+      },
+    };
+    recursivelyDeleteUnsupportedParameters(schema);
+    expect(schema.properties.items).toEqual({
+      type: 'array',
+      items: { type: 'string' },
+    });
+  });
+
+  it('removes object-specific unsupported keywords (minProperties, maxProperties, dependentRequired)', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+      },
+      minProperties: 1,
+      maxProperties: 10,
+      dependentRequired: { name: ['email'] },
+      dependentSchemas: { name: { properties: { email: { type: 'string' } } } },
+    };
+    recursivelyDeleteUnsupportedParameters(schema);
+    expect((schema as any).minProperties).toBeUndefined();
+    expect((schema as any).maxProperties).toBeUndefined();
+    expect((schema as any).dependentRequired).toBeUndefined();
+    expect((schema as any).dependentSchemas).toBeUndefined();
+  });
+
+  it('removes multipleOf keyword', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        quantity: {
+          type: 'integer',
+          multipleOf: 5,
+        },
+      },
+    };
+    recursivelyDeleteUnsupportedParameters(schema);
+    expect(schema.properties.quantity).toEqual({ type: 'integer' });
+  });
+
+  it('removes unsupported properties recursively from nested objects', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        user: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            age: {
+              type: 'integer',
+              exclusiveMinimum: 0,
+              minimum: 0,
+            },
+            profile: {
+              type: 'object',
+              properties: {
+                score: {
+                  type: 'number',
+                  multipleOf: 0.5,
+                  exclusiveMaximum: 100,
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    recursivelyDeleteUnsupportedParameters(schema);
+    expect(schema.properties.user.additionalProperties).toBeUndefined();
+    expect(
+      (schema.properties.user.properties.age as any).exclusiveMinimum
+    ).toBeUndefined();
+    expect(schema.properties.user.properties.age.minimum).toBe(0);
+    expect(
+      (schema.properties.user.properties.profile.properties.score as any)
+        .multipleOf
+    ).toBeUndefined();
+    expect(
+      (schema.properties.user.properties.profile.properties.score as any)
+        .exclusiveMaximum
+    ).toBeUndefined();
+  });
+
+  it('removes unsupported properties from anyOf items', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        value: {
+          anyOf: [
+            { type: 'string', minLength: 1, contentEncoding: 'utf-8' },
+            { type: 'integer', exclusiveMinimum: 0 },
+          ],
+        },
+      },
+    };
+    recursivelyDeleteUnsupportedParameters(schema);
+    expect(schema.properties.value.anyOf).toEqual([
+      { type: 'string', minLength: 1 },
+      { type: 'integer' },
+    ]);
+  });
+
+  it('preserves supported properties (type, format, title, description, etc.)', () => {
+    const schema = {
+      type: 'object',
+      title: 'User',
+      description: 'A user object',
+      properties: {
+        name: {
+          type: 'string',
+          title: 'Name',
+          description: 'The user name',
+          minLength: 1,
+          maxLength: 100,
+          pattern: '^[a-zA-Z]+$',
+          format: 'name',
+        },
+        age: {
+          type: 'integer',
+          minimum: 0,
+          maximum: 150,
+        },
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+          minItems: 0,
+          maxItems: 10,
+        },
+        status: {
+          type: 'string',
+          enum: ['active', 'inactive'],
+          default: 'active',
+          nullable: true,
+        },
+      },
+      required: ['name'],
+    };
+    const originalSchema = JSON.parse(JSON.stringify(schema));
+    recursivelyDeleteUnsupportedParameters(schema);
+    expect(schema).toEqual(originalSchema);
+  });
+
+  it('handles null and non-object inputs gracefully', () => {
+    expect(() => recursivelyDeleteUnsupportedParameters(null)).not.toThrow();
+    expect(() =>
+      recursivelyDeleteUnsupportedParameters(undefined)
+    ).not.toThrow();
+    expect(() =>
+      recursivelyDeleteUnsupportedParameters('string')
+    ).not.toThrow();
+    expect(() => recursivelyDeleteUnsupportedParameters(123)).not.toThrow();
+    expect(() => recursivelyDeleteUnsupportedParameters([])).not.toThrow();
+  });
+
+  it('handles deeply nested schemas', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        level1: {
+          type: 'object',
+          properties: {
+            level2: {
+              type: 'object',
+              properties: {
+                level3: {
+                  type: 'object',
+                  properties: {
+                    value: {
+                      type: 'number',
+                      exclusiveMinimum: 0,
+                      exclusiveMaximum: 100,
+                    },
+                  },
+                  additionalProperties: false,
+                },
+              },
+              additionalProperties: false,
+            },
+          },
+          additionalProperties: false,
+        },
+      },
+      additionalProperties: false,
+    };
+    recursivelyDeleteUnsupportedParameters(schema);
+    expect((schema as any).additionalProperties).toBeUndefined();
+    expect(
+      (schema.properties.level1 as any).additionalProperties
+    ).toBeUndefined();
+    expect(
+      (schema.properties.level1.properties.level2 as any).additionalProperties
+    ).toBeUndefined();
+    expect(
+      (schema.properties.level1.properties.level2.properties.level3 as any)
+        .additionalProperties
+    ).toBeUndefined();
+    expect(
+      (
+        schema.properties.level1.properties.level2.properties.level3.properties
+          .value as any
+      ).exclusiveMinimum
+    ).toBeUndefined();
   });
 });

--- a/src/providers/google-vertex-ai/utils.ts
+++ b/src/providers/google-vertex-ai/utils.ts
@@ -287,7 +287,8 @@ export const transformGeminiToolParameters = (
           continue;
         }
 
-        transformed[key] = transformNode(hadNull ? nonNullItems : value);
+        // Always use 'anyOf' since Vertex AI only supports anyOf, not oneOf
+        transformed.anyOf = transformNode(hadNull ? nonNullItems : value);
         if (hadNull) transformed.nullable = true;
         continue;
       }
@@ -306,9 +307,12 @@ export const transformGeminiToolParameters = (
  *
  * Supported properties: type, format, title, description, nullable, enum,
  * items, properties, required, minItems, maxItems, minimum, maximum,
- * minLength, maxLength, pattern, default, anyOf, propertyOrdering
+ * minLength, maxLength, pattern, default, anyOf, oneOf, propertyOrdering, example
  *
  * All other JSON Schema properties must be removed to avoid validation errors.
+ *
+ * Note: anyOf and oneOf are NOT in this list because they are processed by
+ * transformGeminiToolParameters for nullable type handling.
  */
 const UNSUPPORTED_JSON_SCHEMA_PROPERTIES = [
   // Schema identification and references
@@ -319,6 +323,7 @@ const UNSUPPORTED_JSON_SCHEMA_PROPERTIES = [
   'definitions',
   '$comment',
   '$anchor',
+  '$vocabulary',
 
   // Additional/pattern properties
   'additionalProperties',
@@ -327,7 +332,7 @@ const UNSUPPORTED_JSON_SCHEMA_PROPERTIES = [
   'unevaluatedProperties',
   'unevaluatedItems',
 
-  // Numeric constraints not supported
+  // Numeric constraints not supported by Vertex AI
   'exclusiveMinimum',
   'exclusiveMaximum',
   'multipleOf',
@@ -345,9 +350,8 @@ const UNSUPPORTED_JSON_SCHEMA_PROPERTIES = [
   'prefixItems',
   'uniqueItems',
 
-  // Composition keywords not fully supported
+  // Composition keywords (note: anyOf IS supported, oneOf is NOT fully supported)
   'allOf',
-  'oneOf',
   'not',
 
   // Conditional keywords not supported
@@ -368,10 +372,28 @@ const UNSUPPORTED_JSON_SCHEMA_PROPERTIES = [
   'deprecated',
   'readOnly',
   'writeOnly',
+
+  // OpenAPI-specific keywords not supported
+  'externalDocs',
+  'discriminator',
+  'xml',
 ];
 
-export const recursivelyDeleteUnsupportedParameters = (obj: any) => {
-  if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) return;
+/**
+ * Recursively removes unsupported JSON Schema properties from an object.
+ * Vertex AI has a limited subset of JSON Schema support and will reject
+ * requests containing unsupported properties like exclusiveMinimum.
+ *
+ * @param obj - The JSON Schema object to clean
+ * @see https://cloud.google.com/vertex-ai/docs/reference/rest/v1/Schema
+ */
+export const recursivelyDeleteUnsupportedParameters = (obj: any): void => {
+  if (typeof obj !== 'object' || obj === null) return;
+
+  if (Array.isArray(obj)) {
+    obj.forEach((item) => recursivelyDeleteUnsupportedParameters(item));
+    return;
+  }
 
   for (const prop of UNSUPPORTED_JSON_SCHEMA_PROPERTIES) {
     delete obj[prop];
@@ -380,11 +402,6 @@ export const recursivelyDeleteUnsupportedParameters = (obj: any) => {
   for (const key in obj) {
     if (obj[key] !== null && typeof obj[key] === 'object') {
       recursivelyDeleteUnsupportedParameters(obj[key]);
-    }
-    if (key === 'anyOf' && Array.isArray(obj[key])) {
-      obj[key].forEach((item: any) => {
-        recursivelyDeleteUnsupportedParameters(item);
-      });
     }
   }
 };

--- a/src/providers/google-vertex-ai/utils.ts
+++ b/src/providers/google-vertex-ai/utils.ts
@@ -300,18 +300,88 @@ export const transformGeminiToolParameters = (
   return transformNode(schema);
 };
 
-// Vertex AI does not support additionalProperties in JSON Schema
-// https://cloud.google.com/vertex-ai/docs/reference/rest/v1/Schema
+/**
+ * Vertex AI only supports a subset of JSON Schema properties.
+ * https://cloud.google.com/vertex-ai/docs/reference/rest/v1/Schema
+ *
+ * Supported properties: type, format, title, description, nullable, enum,
+ * items, properties, required, minItems, maxItems, minimum, maximum,
+ * minLength, maxLength, pattern, default, anyOf, propertyOrdering
+ *
+ * All other JSON Schema properties must be removed to avoid validation errors.
+ */
+const UNSUPPORTED_JSON_SCHEMA_PROPERTIES = [
+  // Schema identification and references
+  '$schema',
+  '$id',
+  '$ref',
+  '$defs',
+  'definitions',
+  '$comment',
+  '$anchor',
+
+  // Additional/pattern properties
+  'additionalProperties',
+  'additional_properties',
+  'patternProperties',
+  'unevaluatedProperties',
+  'unevaluatedItems',
+
+  // Numeric constraints not supported
+  'exclusiveMinimum',
+  'exclusiveMaximum',
+  'multipleOf',
+
+  // Object constraints not supported
+  'minProperties',
+  'maxProperties',
+  'dependentRequired',
+  'dependentSchemas',
+
+  // Array constraints not supported
+  'contains',
+  'minContains',
+  'maxContains',
+  'prefixItems',
+  'uniqueItems',
+
+  // Composition keywords not fully supported
+  'allOf',
+  'oneOf',
+  'not',
+
+  // Conditional keywords not supported
+  'if',
+  'then',
+  'else',
+
+  // Const not supported
+  'const',
+
+  // Content keywords not supported
+  'contentEncoding',
+  'contentMediaType',
+  'contentSchema',
+
+  // Annotation keywords not supported
+  'examples',
+  'deprecated',
+  'readOnly',
+  'writeOnly',
+];
+
 export const recursivelyDeleteUnsupportedParameters = (obj: any) => {
   if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) return;
-  delete obj.additional_properties;
-  delete obj.additionalProperties;
-  delete obj['$schema'];
+
+  for (const prop of UNSUPPORTED_JSON_SCHEMA_PROPERTIES) {
+    delete obj[prop];
+  }
+
   for (const key in obj) {
     if (obj[key] !== null && typeof obj[key] === 'object') {
       recursivelyDeleteUnsupportedParameters(obj[key]);
     }
-    if (key == 'anyOf' && Array.isArray(obj[key])) {
+    if (key === 'anyOf' && Array.isArray(obj[key])) {
       obj[key].forEach((item: any) => {
         recursivelyDeleteUnsupportedParameters(item);
       });


### PR DESCRIPTION
**Description:**
- Expanded `recursivelyDeleteUnsupportedParameters` to remove all JSON Schema properties not supported by Vertex AI's Schema API, addressing validation errors caused by properties like `exclusiveMinimum`.
- Updated the list of unsupported properties based on the Vertex AI Schema specification to include numeric, object, array, composition, conditional, content, and annotation keywords.

**Tests Run/Test cases added:**
- [x] Added 16 new test cases in `src/providers/google-vertex-ai/utils.test.ts` to verify the removal of all newly identified unsupported properties, including nested schemas and `anyOf` items.
- [x] Confirmed all existing unit tests pass, and the new tests specifically validate the fix.

**Type of Change:**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

---
<a href="https://cursor.com/background-agent?bcId=bc-e3b46962-0338-4694-ac2b-59df095665e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e3b46962-0338-4694-ac2b-59df095665e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

